### PR TITLE
Add MUI calendar MVP

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,38 +1,4 @@
 .App {
   text-align: center;
-}
-
-.App-logo {
-  height: 40vmin;
-  pointer-events: none;
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  .App-logo {
-    animation: App-logo-spin infinite 20s linear;
-  }
-}
-
-.App-header {
-  background-color: #282c34;
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  font-size: calc(10px + 2vmin);
-  color: white;
-}
-
-.App-link {
-  color: #61dafb;
-}
-
-@keyframes App-logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
+  margin-top: 20px;
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,24 +1,12 @@
-import logo from './logo.svg';
 import './App.css';
+import Calendar from './Calendar';
+import { Container } from '@mui/material';
 
 function App() {
   return (
-    <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.js</code> and save to reload.
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
-      </header>
-    </div>
+    <Container className="App">
+      <Calendar />
+    </Container>
   );
 }
 

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,9 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders calendar header', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const header = screen.getByTestId('month-label');
+  expect(header).toBeInTheDocument();
 });
+

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -1,0 +1,67 @@
+import React, { useState } from 'react';
+import { Box, Typography, IconButton } from '@mui/material';
+import { ChevronLeft, ChevronRight } from '@mui/icons-material';
+
+function generateCalendar(year, month) {
+  const daysInMonth = new Date(year, month + 1, 0).getDate();
+  const firstDay = new Date(year, month, 1).getDay();
+  const weeks = [];
+  let day = 1 - firstDay;
+  while (day <= daysInMonth) {
+    const week = [];
+    for (let i = 0; i < 7; i++) {
+      if (day > 0 && day <= daysInMonth) {
+        week.push(day);
+      } else {
+        week.push(null);
+      }
+      day++;
+    }
+    weeks.push(week);
+  }
+  return weeks;
+}
+
+const daysOfWeek = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+export default function Calendar() {
+  const [currentDate, setCurrentDate] = useState(new Date());
+  const year = currentDate.getFullYear();
+  const month = currentDate.getMonth();
+  const weeks = generateCalendar(year, month);
+
+  const handlePrevMonth = () => {
+    setCurrentDate(new Date(year, month - 1, 1));
+  };
+  const handleNextMonth = () => {
+    setCurrentDate(new Date(year, month + 1, 1));
+  };
+
+  const monthLabel = currentDate.toLocaleString('default', {
+    month: 'long',
+    year: 'numeric'
+  });
+
+  return (
+    <Box sx={{ maxWidth: 400, mx: 'auto', mt: 4 }}>
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
+        <IconButton onClick={handlePrevMonth} data-testid="prev-month"><ChevronLeft /></IconButton>
+        <Typography variant="h6" component="div" data-testid="month-label">{monthLabel}</Typography>
+        <IconButton onClick={handleNextMonth} data-testid="next-month"><ChevronRight /></IconButton>
+      </Box>
+
+      <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)', gap: 1 }}>
+        {daysOfWeek.map(day => (
+          <Typography key={day} variant="subtitle2" align="center" fontWeight="bold">
+            {day}
+          </Typography>
+        ))}
+        {weeks.flat().map((day, idx) => (
+          <Box key={idx} sx={{ border: '1px solid #e0e0e0', height: 40, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            {day || ''}
+          </Box>
+        ))}
+      </Box>
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary
- replace CRA boilerplate with simple Material UI calendar
- add tests for calendar header

## Testing
- `npm test --silent -- -u` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848e1b13a708326a3a3c4cc8b6015d6