### PR TITLE
Add event list beside calendar

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -8,6 +8,7 @@ import { useState, useEffect } from 'react';
 function App() {
   const [dialogOpen, setDialogOpen] = useState(false);
   const [selectedDate, setSelectedDate] = useState(null);
+  const [editingEvent, setEditingEvent] = useState(null);
   const [events, setEvents] = useState(() => {
     const stored = localStorage.getItem('events');
     return stored ? JSON.parse(stored) : [];
@@ -19,18 +20,30 @@ function App() {
 
   const handleDateClick = (date) => {
     setSelectedDate(date);
+    setEditingEvent(null);
     setDialogOpen(true);
   };
 
   const handleClose = () => {
     setDialogOpen(false);
+    setEditingEvent(null);
+  };
+
+  const handleEditEvent = (event) => {
+    setSelectedDate(null);
+    setEditingEvent(event);
+    setDialogOpen(true);
+  };
+
+  const handleDeleteEvent = (id) => {
+    setEvents(events.filter(ev => ev.id !== id));
   };
 
   return (
     <Container className="App">
       <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'flex-start', gap: 4 }}>
         <Calendar onDateClick={handleDateClick} />
-        <EventList events={events} />
+        <EventList events={events} onEdit={handleEditEvent} onDelete={handleDeleteEvent} />
       </Box>
       <EventManager
         open={dialogOpen}
@@ -38,6 +51,7 @@ function App() {
         defaultDate={selectedDate}
         events={events}
         setEvents={setEvents}
+        editingEvent={editingEvent}
       />
     </Container>
   );

--- a/src/App.js
+++ b/src/App.js
@@ -1,12 +1,21 @@
 import './App.css';
 import Calendar from './Calendar';
 import EventManager from './EventManager';
-import { Container } from '@mui/material';
-import { useState } from 'react';
+import EventList from './EventList';
+import { Container, Box } from '@mui/material';
+import { useState, useEffect } from 'react';
 
 function App() {
   const [dialogOpen, setDialogOpen] = useState(false);
   const [selectedDate, setSelectedDate] = useState(null);
+  const [events, setEvents] = useState(() => {
+    const stored = localStorage.getItem('events');
+    return stored ? JSON.parse(stored) : [];
+  });
+
+  useEffect(() => {
+    localStorage.setItem('events', JSON.stringify(events));
+  }, [events]);
 
   const handleDateClick = (date) => {
     setSelectedDate(date);
@@ -19,11 +28,16 @@ function App() {
 
   return (
     <Container className="App">
-      <Calendar onDateClick={handleDateClick} />
+      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'flex-start', gap: 4 }}>
+        <Calendar onDateClick={handleDateClick} />
+        <EventList events={events} />
+      </Box>
       <EventManager
         open={dialogOpen}
         onClose={handleClose}
         defaultDate={selectedDate}
+        events={events}
+        setEvents={setEvents}
       />
     </Container>
   );

--- a/src/EventList.js
+++ b/src/EventList.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Box, List, ListItem, Typography } from '@mui/material';
+
+export default function EventList({ events }) {
+  return (
+    <Box sx={{ width: 300 }}>
+      <Typography variant="h6" align="center" gutterBottom>
+        All Events
+      </Typography>
+      <List>
+        {events.length === 0 && (
+          <ListItem>
+            <Typography variant="body2">No events</Typography>
+          </ListItem>
+        )}
+        {events.map((ev) => (
+          <ListItem key={ev.id}>
+            <Box sx={{ flexGrow: 1 }}>
+              <Typography variant="subtitle1">{ev.title}</Typography>
+              <Typography variant="body2">
+                {new Date(ev.dateTime).toLocaleString()}
+                {ev.duration ? ` - ${ev.duration} min` : ''}
+              </Typography>
+            </Box>
+          </ListItem>
+        ))}
+      </List>
+    </Box>
+  );
+}

--- a/src/EventList.js
+++ b/src/EventList.js
@@ -1,7 +1,8 @@
 import React from 'react';
-import { Box, List, ListItem, Typography } from '@mui/material';
+import { Box, List, ListItem, Typography, IconButton } from '@mui/material';
+import { Edit, Delete } from '@mui/icons-material';
 
-export default function EventList({ events }) {
+export default function EventList({ events, onEdit, onDelete }) {
   return (
     <Box sx={{ width: 300 }}>
       <Typography variant="h6" align="center" gutterBottom>
@@ -14,7 +15,19 @@ export default function EventList({ events }) {
           </ListItem>
         )}
         {events.map((ev) => (
-          <ListItem key={ev.id}>
+          <ListItem
+            key={ev.id}
+            secondaryAction={
+              <Box>
+                <IconButton edge="end" aria-label="edit" onClick={() => onEdit && onEdit(ev)}>
+                  <Edit />
+                </IconButton>
+                <IconButton edge="end" aria-label="delete" onClick={() => onDelete && onDelete(ev.id)}>
+                  <Delete />
+                </IconButton>
+              </Box>
+            }
+          >
             <Box sx={{ flexGrow: 1 }}>
               <Typography variant="subtitle1">{ev.title}</Typography>
               <Typography variant="body2">

--- a/src/EventManager.js
+++ b/src/EventManager.js
@@ -25,11 +25,7 @@ function isSameDay(d1, d2) {
   );
 }
 
-export default function EventManager({ open, onClose, defaultDate }) {
-  const [events, setEvents] = useState(() => {
-    const stored = localStorage.getItem('events');
-    return stored ? JSON.parse(stored) : [];
-  });
+export default function EventManager({ open, onClose, defaultDate, events, setEvents }) {
 
   const [title, setTitle] = useState('');
   const [dateTime, setDateTime] = useState(new Date());
@@ -42,9 +38,6 @@ export default function EventManager({ open, onClose, defaultDate }) {
     }
   }, [open, defaultDate]);
 
-  useEffect(() => {
-    localStorage.setItem('events', JSON.stringify(events));
-  }, [events]);
 
   const resetForm = () => {
     setTitle('');

--- a/src/EventManager.js
+++ b/src/EventManager.js
@@ -25,7 +25,7 @@ function isSameDay(d1, d2) {
   );
 }
 
-export default function EventManager({ open, onClose, defaultDate, events, setEvents }) {
+export default function EventManager({ open, onClose, defaultDate, events, setEvents, editingEvent }) {
 
   const [title, setTitle] = useState('');
   const [dateTime, setDateTime] = useState(new Date());
@@ -37,6 +37,21 @@ export default function EventManager({ open, onClose, defaultDate, events, setEv
       setDateTime(new Date(defaultDate));
     }
   }, [open, defaultDate]);
+
+  useEffect(() => {
+    if (!open) {
+      resetForm();
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (editingEvent) {
+      setTitle(editingEvent.title);
+      setDateTime(new Date(editingEvent.dateTime));
+      setDuration(editingEvent.duration || '');
+      setEditingId(editingEvent.id);
+    }
+  }, [editingEvent]);
 
 
   const resetForm = () => {


### PR DESCRIPTION
## Summary
- maintain events in `App` component using localStorage
- add new `EventList` component that displays all events
- display `EventList` next to the calendar
- update `EventManager` to receive and modify shared events

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848ece5d5f08326bb5f54fef35fed7f