### PR TITLE
Improve UI styling

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,4 +1,4 @@
 .App {
   text-align: center;
-  margin-top: 20px;
+  padding-top: 80px;
 }

--- a/src/App.js
+++ b/src/App.js
@@ -2,7 +2,14 @@ import './App.css';
 import Calendar from './Calendar';
 import EventManager from './EventManager';
 import EventList from './EventList';
-import { Container, Box } from '@mui/material';
+import {
+  Container,
+  Box,
+  AppBar,
+  Toolbar,
+  Typography,
+  Paper
+} from '@mui/material';
 import { useState, useEffect } from 'react';
 
 function App() {
@@ -40,20 +47,33 @@ function App() {
   };
 
   return (
-    <Container className="App">
-      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'flex-start', gap: 4 }}>
-        <Calendar onDateClick={handleDateClick} />
-        <EventList events={events} onEdit={handleEditEvent} onDelete={handleDeleteEvent} />
-      </Box>
-      <EventManager
-        open={dialogOpen}
-        onClose={handleClose}
-        defaultDate={selectedDate}
-        events={events}
-        setEvents={setEvents}
-        editingEvent={editingEvent}
-      />
-    </Container>
+    <>
+      <AppBar position="fixed" color="primary" enableColorOnDark>
+        <Toolbar>
+          <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
+            My Calendar
+          </Typography>
+        </Toolbar>
+      </AppBar>
+      <Container maxWidth="md" className="App">
+        <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'flex-start', gap: 4 }}>
+          <Paper sx={{ p: 2, flexGrow: 1 }}>
+            <Calendar onDateClick={handleDateClick} />
+          </Paper>
+          <Paper sx={{ p: 2, width: 320 }}>
+            <EventList events={events} onEdit={handleEditEvent} onDelete={handleDeleteEvent} />
+          </Paper>
+        </Box>
+        <EventManager
+          open={dialogOpen}
+          onClose={handleClose}
+          defaultDate={selectedDate}
+          events={events}
+          setEvents={setEvents}
+          editingEvent={editingEvent}
+        />
+      </Container>
+    </>
   );
 }
 

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Box, Typography, IconButton } from '@mui/material';
+import { Box, Typography, IconButton, Paper } from '@mui/material';
 import { ChevronLeft, ChevronRight } from '@mui/icons-material';
 
 function generateCalendar(year, month) {
@@ -43,13 +43,12 @@ export default function Calendar({ onDateClick }) {
   });
 
   return (
-    <Box sx={{ maxWidth: 400, mx: 'auto', mt: 4 }}>
+    <Paper sx={{ maxWidth: 400, mx: 'auto', mt: 2, p: 2 }}>
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
         <IconButton onClick={handlePrevMonth} data-testid="prev-month"><ChevronLeft /></IconButton>
         <Typography variant="h6" component="div" data-testid="month-label">{monthLabel}</Typography>
         <IconButton onClick={handleNextMonth} data-testid="next-month"><ChevronRight /></IconButton>
       </Box>
-
       <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)', gap: 1 }}>
         {daysOfWeek.map(day => (
           <Typography key={day} variant="subtitle2" align="center" fontWeight="bold">
@@ -60,12 +59,17 @@ export default function Calendar({ onDateClick }) {
           <Box
             key={idx}
             sx={{
-              border: '1px solid #e0e0e0',
+              border: 1,
+              borderColor: 'divider',
               height: 40,
               display: 'flex',
               alignItems: 'center',
               justifyContent: 'center',
-              cursor: day ? 'pointer' : 'default'
+              cursor: day ? 'pointer' : 'default',
+              borderRadius: 1,
+              '&:hover': {
+                backgroundColor: day ? 'action.hover' : 'transparent'
+              }
             }}
             onClick={() => day && onDateClick && onDateClick(new Date(year, month, day))}
             data-testid={day ? `day-${day}` : undefined}
@@ -74,6 +78,6 @@ export default function Calendar({ onDateClick }) {
           </Box>
         ))}
       </Box>
-    </Box>
+    </Paper>
   );
 }

--- a/src/EventList.js
+++ b/src/EventList.js
@@ -1,14 +1,14 @@
 import React from 'react';
-import { Box, List, ListItem, Typography, IconButton } from '@mui/material';
+import { Box, List, ListItem, Typography, IconButton, Paper } from '@mui/material';
 import { Edit, Delete } from '@mui/icons-material';
 
 export default function EventList({ events, onEdit, onDelete }) {
   return (
-    <Box sx={{ width: 300 }}>
+    <Paper sx={{ width: 300, p: 2 }}>
       <Typography variant="h6" align="center" gutterBottom>
-        All Events
+        Events
       </Typography>
-      <List>
+      <List sx={{ maxHeight: 400, overflow: 'auto' }}>
         {events.length === 0 && (
           <ListItem>
             <Typography variant="body2">No events</Typography>
@@ -38,6 +38,6 @@ export default function EventList({ events, onEdit, onDelete }) {
           </ListItem>
         ))}
       </List>
-    </Box>
+    </Paper>
   );
 }

--- a/src/EventManager.js
+++ b/src/EventManager.js
@@ -101,7 +101,7 @@ export default function EventManager({ open, onClose, defaultDate, events, setEv
     : events;
 
   return (
-    <Dialog open={open} onClose={onClose} fullWidth>
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
       <DialogTitle>
         Manage Events{defaultDate ? ` - ${new Date(defaultDate).toDateString()}` : ''}
       </DialogTitle>
@@ -135,7 +135,12 @@ export default function EventManager({ open, onClose, defaultDate, events, setEv
             {editingId ? 'Update' : 'Add'}
           </Button>
         </Box>
-        <List>
+        <List sx={{ maxHeight: 300, overflow: 'auto' }}>
+          {eventsForDay.length === 0 && (
+            <ListItem>
+              <Typography variant="body2">No events</Typography>
+            </ListItem>
+          )}
           {eventsForDay.map((ev) => (
             <ListItem
               key={ev.id}

--- a/src/index.css
+++ b/src/index.css
@@ -5,6 +5,7 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  background-color: #f5f5f5;
 }
 
 code {


### PR DESCRIPTION
## Summary
- style Calendar & event list with Material UI `Paper`
- add top AppBar and modern layout
- minor tweaks to dialog and lists
- adjust background and padding for cleaner look

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848eff218e0832684f46ee356f64374