### PR TITLE
Simplify calendar layout

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -7,8 +7,7 @@ import {
   Box,
   AppBar,
   Toolbar,
-  Typography,
-  Paper
+  Typography
 } from '@mui/material';
 import { useState, useEffect } from 'react';
 
@@ -56,13 +55,13 @@ function App() {
         </Toolbar>
       </AppBar>
       <Container maxWidth="md" className="App">
-        <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'flex-start', gap: 4 }}>
-          <Paper sx={{ p: 2, flexGrow: 1 }}>
+        <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 2, width: '100%' }}>
+          <Box sx={{ flexBasis: '65%', flexGrow: 1 }}>
             <Calendar onDateClick={handleDateClick} />
-          </Paper>
-          <Paper sx={{ p: 2, width: 320 }}>
+          </Box>
+          <Box sx={{ flexBasis: '35%' }}>
             <EventList events={events} onEdit={handleEditEvent} onDelete={handleDeleteEvent} />
-          </Paper>
+          </Box>
         </Box>
         <EventManager
           open={dialogOpen}

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Box, Typography, IconButton, Paper } from '@mui/material';
+import { Box, Typography, IconButton } from '@mui/material';
 import { ChevronLeft, ChevronRight } from '@mui/icons-material';
 
 function generateCalendar(year, month) {
@@ -43,7 +43,7 @@ export default function Calendar({ onDateClick }) {
   });
 
   return (
-    <Paper sx={{ maxWidth: 400, mx: 'auto', mt: 2, p: 2 }}>
+    <Box sx={{ width: '100%', p: 2 }}>
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
         <IconButton onClick={handlePrevMonth} data-testid="prev-month"><ChevronLeft /></IconButton>
         <Typography variant="h6" component="div" data-testid="month-label">{monthLabel}</Typography>
@@ -61,7 +61,7 @@ export default function Calendar({ onDateClick }) {
             sx={{
               border: 1,
               borderColor: 'divider',
-              height: 40,
+              height: 60,
               display: 'flex',
               alignItems: 'center',
               justifyContent: 'center',
@@ -78,6 +78,6 @@ export default function Calendar({ onDateClick }) {
           </Box>
         ))}
       </Box>
-    </Paper>
+    </Box>
   );
 }

--- a/src/EventList.js
+++ b/src/EventList.js
@@ -1,14 +1,14 @@
 import React from 'react';
-import { Box, List, ListItem, Typography, IconButton, Paper } from '@mui/material';
+import { Box, List, ListItem, Typography, IconButton } from '@mui/material';
 import { Edit, Delete } from '@mui/icons-material';
 
 export default function EventList({ events, onEdit, onDelete }) {
   return (
-    <Paper sx={{ width: 300, p: 2 }}>
+    <Box sx={{ width: '100%', p: 2 }}>
       <Typography variant="h6" align="center" gutterBottom>
         Events
       </Typography>
-      <List sx={{ maxHeight: 400, overflow: 'auto' }}>
+      <List sx={{ maxHeight: '70vh', overflow: 'auto', p: 0 }}>
         {events.length === 0 && (
           <ListItem>
             <Typography variant="body2">No events</Typography>
@@ -38,6 +38,6 @@ export default function EventList({ events, onEdit, onDelete }) {
           </ListItem>
         ))}
       </List>
-    </Paper>
+    </Box>
   );
 }


### PR DESCRIPTION
## Summary
- remove Material UI Paper wrappers from Calendar and EventList
- enlarge day cells and events list area
- use percentage-based widths for Calendar and Events column

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_6849e7bf0ef883319335e95cb2034c4e