### PR TITLE
Make events clickable and restrict deletion

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -41,9 +41,6 @@ function App() {
     setDialogOpen(true);
   };
 
-  const handleDeleteEvent = (id) => {
-    setEvents(events.filter(ev => ev.id !== id));
-  };
 
   return (
     <>
@@ -60,7 +57,7 @@ function App() {
             <Calendar onDateClick={handleDateClick} />
           </Box>
           <Box sx={{ flexBasis: '35%' }}>
-            <EventList events={events} onEdit={handleEditEvent} onDelete={handleDeleteEvent} />
+            <EventList events={events} onEdit={handleEditEvent} />
           </Box>
         </Box>
         <EventManager

--- a/src/EventList.js
+++ b/src/EventList.js
@@ -1,8 +1,7 @@
 import React from 'react';
-import { Box, List, ListItem, Typography, IconButton } from '@mui/material';
-import { Edit, Delete } from '@mui/icons-material';
+import { Box, List, ListItemButton, Typography } from '@mui/material';
 
-export default function EventList({ events, onEdit, onDelete }) {
+export default function EventList({ events, onEdit }) {
   return (
     <Box sx={{ width: '100%', p: 2 }}>
       <Typography variant="h6" align="center" gutterBottom>
@@ -10,24 +9,12 @@ export default function EventList({ events, onEdit, onDelete }) {
       </Typography>
       <List sx={{ maxHeight: '70vh', overflow: 'auto', p: 0 }}>
         {events.length === 0 && (
-          <ListItem>
+          <ListItemButton disabled>
             <Typography variant="body2">No events</Typography>
-          </ListItem>
+          </ListItemButton>
         )}
         {events.map((ev) => (
-          <ListItem
-            key={ev.id}
-            secondaryAction={
-              <Box>
-                <IconButton edge="end" aria-label="edit" onClick={() => onEdit && onEdit(ev)}>
-                  <Edit />
-                </IconButton>
-                <IconButton edge="end" aria-label="delete" onClick={() => onDelete && onDelete(ev.id)}>
-                  <Delete />
-                </IconButton>
-              </Box>
-            }
-          >
+          <ListItemButton key={ev.id} onClick={() => onEdit && onEdit(ev)}>
             <Box sx={{ flexGrow: 1 }}>
               <Typography variant="subtitle1">{ev.title}</Typography>
               <Typography variant="body2">
@@ -35,7 +22,7 @@ export default function EventList({ events, onEdit, onDelete }) {
                 {ev.duration ? ` - ${ev.duration} min` : ''}
               </Typography>
             </Box>
-          </ListItem>
+          </ListItemButton>
         ))}
       </List>
     </Box>

--- a/src/EventManager.js
+++ b/src/EventManager.js
@@ -167,6 +167,11 @@ export default function EventManager({ open, onClose, defaultDate, events, setEv
         </List>
       </DialogContent>
       <DialogActions>
+        {editingId && (
+          <Button color="error" onClick={() => { handleDelete(editingId); onClose(); }}>
+            Delete
+          </Button>
+        )}
         <Button onClick={onClose}>Close</Button>
       </DialogActions>
     </Dialog>


### PR DESCRIPTION
## Summary
- make event list items buttons
- open event manager via button click
- prevent deletion from event list
- allow deletion from event manager using a new Delete button

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_6849ef081f8883319112f49dfb313ef5