### PR TITLE
Sort events chronologically in list

### DIFF
--- a/src/EventList.js
+++ b/src/EventList.js
@@ -2,18 +2,21 @@ import React from 'react';
 import { Box, List, ListItemButton, Typography } from '@mui/material';
 
 export default function EventList({ events, onEdit }) {
+  const sortedEvents = [...events].sort(
+    (a, b) => new Date(a.dateTime) - new Date(b.dateTime)
+  );
   return (
     <Box sx={{ width: '100%', p: 2 }}>
       <Typography variant="h6" align="center" gutterBottom>
         Events
       </Typography>
       <List sx={{ maxHeight: '70vh', overflow: 'auto', p: 0 }}>
-        {events.length === 0 && (
+        {sortedEvents.length === 0 && (
           <ListItemButton disabled>
             <Typography variant="body2">No events</Typography>
           </ListItemButton>
         )}
-        {events.map((ev) => (
+        {sortedEvents.map((ev) => (
           <ListItemButton key={ev.id} onClick={() => onEdit && onEdit(ev)}>
             <Box sx={{ flexGrow: 1 }}>
               <Typography variant="subtitle1">{ev.title}</Typography>


### PR DESCRIPTION
## Summary
- sort events in the `EventList` component before rendering

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_6849f08aeb548331b32cfe3a964de2e9