### PR TITLE
Add confirm before deleting events

### DIFF
--- a/src/EventManager.js
+++ b/src/EventManager.js
@@ -88,6 +88,9 @@ export default function EventManager({ open, onClose, defaultDate, events, setEv
   };
 
   const handleDelete = (id) => {
+    if (!window.confirm('Are you sure you want to delete this event?')) {
+      return;
+    }
     setEvents(events.filter(ev => ev.id !== id));
     if (editingId === id) {
       resetForm();


### PR DESCRIPTION
## Summary
- prompt the user for confirmation in `EventManager` before deleting

## Testing
- `npm test --silent -- -u` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_6849f2c64fe4833182d5b5981ab0183d