### PR TITLE
Add color-coordinated events

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -19,12 +19,15 @@ test('shows indicator on day with events', () => {
   const event = {
     id: 1,
     title: 'Test',
-    dateTime: today.toISOString()
+    dateTime: today.toISOString(),
+    color: '#ff0000'
   };
   window.localStorage.setItem('events', JSON.stringify([event]));
   render(<App />);
   const dayCell = screen.getByTestId(`day-${today.getDate()}`);
   expect(dayCell).toHaveAttribute('data-has-events', 'true');
+  const dot = screen.getByTestId(`event-dot-${today.getDate()}-0`);
+  expect(dot).toHaveStyle(`background-color: ${event.color}`);
   window.localStorage.removeItem('events');
 });
 

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -71,9 +71,10 @@ export default function Calendar({ onDateClick, events = [] }) {
             today.getDate() === day &&
             today.getMonth() === month &&
             today.getFullYear() === year;
-          const hasEvents = day && events.some(ev =>
+          const eventsForDay = day ? events.filter(ev =>
             isSameDay(new Date(ev.dateTime), new Date(year, month, day))
-          );
+          ) : [];
+          const hasEvents = eventsForDay.length > 0;
           return (
             <Box
               key={idx}
@@ -107,12 +108,23 @@ export default function Calendar({ onDateClick, events = [] }) {
                     bottom: 4,
                     left: '50%',
                     transform: 'translateX(-50%)',
-                    width: 6,
-                    height: 6,
-                    borderRadius: '50%',
-                    backgroundColor: 'secondary.main'
+                    display: 'flex',
+                    gap: 0.5
                   }}
-                />
+                >
+                  {eventsForDay.slice(0,3).map((ev, i) => (
+                    <Box
+                      key={i}
+                      data-testid={`event-dot-${day}-${i}`}
+                      sx={{
+                        width: 6,
+                        height: 6,
+                        borderRadius: '50%',
+                        backgroundColor: ev.color || 'secondary.main'
+                      }}
+                    />
+                  ))}
+                </Box>
               )}
             </Box>
           );

--- a/src/EventList.js
+++ b/src/EventList.js
@@ -33,6 +33,7 @@ export default function EventList({ events, onEdit }) {
               }
             }}
           >
+            <Box sx={{ width: 12, height: 12, borderRadius: '50%', backgroundColor: ev.color || 'secondary.main', mr: 2 }} />
             <Box sx={{ flexGrow: 1 }}>
               <Typography variant="subtitle1">{ev.title}</Typography>
               <Typography variant="body2">

--- a/src/EventManager.js
+++ b/src/EventManager.js
@@ -38,6 +38,7 @@ export default function EventManager({ open, onClose, defaultDate, events, setEv
   const [duration, setDuration] = useState('');
   const [location, setLocation] = useState('');
   const [description, setDescription] = useState('');
+  const [color, setColor] = useState('#2196f3');
   const [editingId, setEditingId] = useState(null);
 
   useEffect(() => {
@@ -59,6 +60,7 @@ export default function EventManager({ open, onClose, defaultDate, events, setEv
       setDuration(editingEvent.duration || '');
       setLocation(editingEvent.location || '');
       setDescription(editingEvent.description || '');
+      setColor(editingEvent.color || '#2196f3');
       setEditingId(editingEvent.id);
     }
   }, [editingEvent]);
@@ -70,6 +72,7 @@ export default function EventManager({ open, onClose, defaultDate, events, setEv
     setDuration('');
     setLocation('');
     setDescription('');
+    setColor('#2196f3');
     setEditingId(null);
   };
 
@@ -82,7 +85,8 @@ export default function EventManager({ open, onClose, defaultDate, events, setEv
       dateTime: dateTime ? dateTime.toISOString() : new Date().toISOString(),
       duration,
       location,
-      description
+      description,
+      color
     };
     if (editingId) {
       setEvents(events.map(ev => (ev.id === editingId ? event : ev)));
@@ -100,6 +104,7 @@ export default function EventManager({ open, onClose, defaultDate, events, setEv
     setDuration(ev.duration || '');
     setLocation(ev.location || '');
     setDescription(ev.description || '');
+    setColor(ev.color || '#2196f3');
     setEditingId(id);
   };
 
@@ -170,17 +175,25 @@ export default function EventManager({ open, onClose, defaultDate, events, setEv
             value={duration}
             onChange={(e) => setDuration(e.target.value)}
           />
-          <TextField
-            label="Location"
-            value={location}
-            onChange={(e) => setLocation(e.target.value)}
-            fullWidth
-          />
-          <TextField
-            label="Description"
-            value={description}
-            onChange={(e) => setDescription(e.target.value)}
-            multiline
+        <TextField
+          label="Location"
+          value={location}
+          onChange={(e) => setLocation(e.target.value)}
+          fullWidth
+        />
+        <TextField
+          label="Color"
+          type="color"
+          value={color}
+          onChange={(e) => setColor(e.target.value)}
+          sx={{ width: 80 }}
+          InputLabelProps={{ shrink: true }}
+        />
+        <TextField
+          label="Description"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          multiline
             rows={3}
             fullWidth
           />
@@ -206,6 +219,7 @@ export default function EventManager({ open, onClose, defaultDate, events, setEv
                 onClick={() => handleEdit(ev.id)}
                 button
               >
+                <Box sx={{ width: 12, height: 12, borderRadius: '50%', backgroundColor: ev.color || 'secondary.main', mr: 2 }} />
                 <Box sx={{ flexGrow: 1 }}>
                   <Typography variant="subtitle1">{ev.title}</Typography>
                   <Typography variant="body2">


### PR DESCRIPTION
## Summary
- add color field to events and expose color picker in EventManager
- show color indicator next to events in EventManager and EventList
- color-code calendar dots using each event's color
- test indicator color

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test --silent -- -u` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_6849f9c087848331befcd195eb0819cd