### PR TITLE
Limit event colors to predefined palette

### DIFF
--- a/src/EventManager.js
+++ b/src/EventManager.js
@@ -52,6 +52,16 @@ export default function EventManager({ open, onClose, defaultDate, events, setEv
   const [color, setColor] = useState(COLOR_OPTIONS[0].value);
   const [editingId, setEditingId] = useState(null);
 
+  const resetForm = useCallback(() => {
+    setTitle('');
+    setDateTime(createDefaultDateTime());
+    setDuration('');
+    setLocation('');
+    setDescription('');
+    setColor(COLOR_OPTIONS[0].value);
+    setEditingId(null);
+  }, [createDefaultDateTime]);
+
   useEffect(() => {
     if (open && defaultDate) {
       setDateTime(createDefaultDateTime(defaultDate));
@@ -75,17 +85,6 @@ export default function EventManager({ open, onClose, defaultDate, events, setEv
       setEditingId(editingEvent.id);
     }
   }, [editingEvent]);
-
-
-  const resetForm = useCallback(() => {
-    setTitle('');
-    setDateTime(createDefaultDateTime());
-    setDuration('');
-    setLocation('');
-    setDescription('');
-    setColor(COLOR_OPTIONS[0].value);
-    setEditingId(null);
-  }, [createDefaultDateTime]);
 
   const handleSubmit = (e) => {
     e.preventDefault();


### PR DESCRIPTION
## Summary
- restrict event colors to a fixed set of seven options
- replace color input with a select menu showing color names and swatches

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test --silent -- -u` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_6849fc124da4833188cffda6bfbb369a