### PR TITLE
fix event dialog close

### DIFF
--- a/src/EventManager.js
+++ b/src/EventManager.js
@@ -104,6 +104,7 @@ export default function EventManager({ open, onClose, defaultDate, events, setEv
       setEvents([...events, event]);
     }
     resetForm();
+    onClose();
   };
 
   const handleEdit = (id) => {


### PR DESCRIPTION
## Summary
- close the EventManager dialog after adding or updating an event

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_6849ff7593b083318aca1455075577e8