### PR TITLE
Add Today button to Calendar

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import App from './App';
 
 test('renders calendar header', () => {
@@ -29,5 +29,16 @@ test('shows indicator on day with events', () => {
   const dot = screen.getByTestId(`event-dot-${today.getDate()}-0`);
   expect(dot).toHaveStyle(`background-color: ${event.color}`);
   window.localStorage.removeItem('events');
+});
+
+test('today button resets the calendar', () => {
+  render(<App />);
+  const nextBtn = screen.getByTestId('next-month');
+  fireEvent.click(nextBtn);
+  const todayLabel = new Date().toLocaleString('default', { month: 'long', year: 'numeric' });
+  expect(screen.getByTestId('month-label').textContent).not.toBe(todayLabel);
+  const todayBtn = screen.getByTestId('today-button');
+  fireEvent.click(todayBtn);
+  expect(screen.getByTestId('month-label').textContent).toBe(todayLabel);
 });
 

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -4,9 +4,10 @@ import {
   Typography,
   IconButton,
   ToggleButton,
-  ToggleButtonGroup
+  ToggleButtonGroup,
+  Button
 } from '@mui/material';
-import { ChevronLeft, ChevronRight } from '@mui/icons-material';
+import { ChevronLeft, ChevronRight, Today as TodayIcon } from '@mui/icons-material';
 
 function generateCalendar(year, month) {
   const daysInMonth = new Date(year, month + 1, 0).getDate();
@@ -107,9 +108,19 @@ export default function Calendar({ onDateClick, events = [] }) {
   return (
     <Box sx={{ width: '100%', p: 2 }}>
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
-        <IconButton onClick={handlePrev} data-testid="prev-month"><ChevronLeft /></IconButton>
+        <Box>
+          <IconButton onClick={handlePrev} data-testid="prev-month"><ChevronLeft /></IconButton>
+          <IconButton onClick={handleNext} data-testid="next-month"><ChevronRight /></IconButton>
+        </Box>
         <Typography variant="h6" component="div" data-testid="month-label">{monthLabel}</Typography>
-        <IconButton onClick={handleNext} data-testid="next-month"><ChevronRight /></IconButton>
+        <Button
+          onClick={() => setCurrentDate(new Date())}
+          data-testid="today-button"
+          startIcon={<TodayIcon />}
+          size="small"
+        >
+          Today
+        </Button>
       </Box>
       <ToggleButtonGroup
         value={view}


### PR DESCRIPTION
## Summary
- add a Today button in Calendar
- update tests for new button

## Testing
- `npm test -- -u --watchAll=false` *(fails: `react-scripts` not found)*

------
https://chatgpt.com/codex/tasks/task_b_684a085d999483318fc5368c13f6e13b