### PR TITLE
Highlight date in calendar when hovering event

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -15,6 +15,7 @@ function App() {
   const [dialogOpen, setDialogOpen] = useState(false);
   const [selectedDate, setSelectedDate] = useState(null);
   const [editingEvent, setEditingEvent] = useState(null);
+  const [hoveredDate, setHoveredDate] = useState(null);
   const [events, setEvents] = useState(() => {
     const stored = localStorage.getItem('events');
     return stored ? JSON.parse(stored) : [];
@@ -54,10 +55,10 @@ function App() {
       <Container maxWidth="md" className="App">
         <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 2, width: '100%' }}>
           <Box sx={{ flexBasis: '65%', flexGrow: 1 }}>
-            <Calendar onDateClick={handleDateClick} events={events} />
+            <Calendar onDateClick={handleDateClick} events={events} hoveredDate={hoveredDate} />
           </Box>
           <Box sx={{ flexBasis: '35%' }}>
-            <EventList events={events} onEdit={handleEditEvent} />
+            <EventList events={events} onEdit={handleEditEvent} onHoverDate={setHoveredDate} />
           </Box>
         </Box>
         <EventManager

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -42,3 +42,23 @@ test('today button resets the calendar', () => {
   expect(screen.getByTestId('month-label').textContent).toBe(todayLabel);
 });
 
+test('highlights date on event hover', () => {
+  const today = new Date();
+  const event = {
+    id: 2,
+    title: 'Hover Test',
+    dateTime: today.toISOString(),
+    color: '#00ff00'
+  };
+  window.localStorage.setItem('events', JSON.stringify([event]));
+  render(<App />);
+  const dayCell = screen.getByTestId(`day-${today.getDate()}`);
+  const eventItem = screen.getByText('Hover Test').closest('button');
+  expect(dayCell).not.toHaveAttribute('data-hovered', 'true');
+  fireEvent.mouseOver(eventItem);
+  expect(dayCell).toHaveAttribute('data-hovered', 'true');
+  fireEvent.mouseLeave(eventItem);
+  expect(dayCell).not.toHaveAttribute('data-hovered', 'true');
+  window.localStorage.removeItem('events');
+});
+

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -52,7 +52,7 @@ function isSameDay(d1, d2) {
   );
 }
 
-export default function Calendar({ onDateClick, events = [] }) {
+export default function Calendar({ onDateClick, events = [], hoveredDate }) {
   const [currentDate, setCurrentDate] = useState(new Date());
   const [view, setView] = useState('month'); // month | week | day
   const year = currentDate.getFullYear();
@@ -143,6 +143,7 @@ export default function Calendar({ onDateClick, events = [] }) {
           const dateObj = view === 'month' ? (d ? new Date(year, month, d) : null) : d;
           const dayNumber = view === 'month' ? d : d.getDate();
           const isToday = dateObj && isSameDay(dateObj, today);
+          const isHovered = dateObj && hoveredDate && isSameDay(dateObj, hoveredDate);
           const eventsForDay = dateObj ? events.filter(ev =>
             isSameDay(new Date(ev.dateTime), dateObj)
           ) : [];
@@ -160,7 +161,11 @@ export default function Calendar({ onDateClick, events = [] }) {
                 cursor: dateObj ? 'pointer' : 'default',
                 borderRadius: 1,
                 position: 'relative',
-                backgroundColor: isToday ? 'primary.main' : undefined,
+                backgroundColor: isToday
+                  ? 'primary.main'
+                  : isHovered
+                  ? 'action.selected'
+                  : undefined,
                 color: isToday ? 'primary.contrastText' : undefined,
                 '&:hover': {
                   backgroundColor: dateObj ? 'action.hover' : 'transparent'
@@ -169,6 +174,7 @@ export default function Calendar({ onDateClick, events = [] }) {
               onClick={() => dateObj && onDateClick && onDateClick(dateObj)}
               data-testid={dateObj ? `day-${dayNumber}` : undefined}
               data-today={isToday ? 'true' : undefined}
+              data-hovered={isHovered ? 'true' : undefined}
               data-has-events={hasEvents ? 'true' : undefined}
             >
               {dayNumber || ''}

--- a/src/EventList.js
+++ b/src/EventList.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Box, List, ListItemButton, Typography } from '@mui/material';
 
-export default function EventList({ events, onEdit }) {
+export default function EventList({ events, onEdit, onHoverDate }) {
   const sortedEvents = [...events].sort(
     (a, b) => new Date(a.dateTime) - new Date(b.dateTime)
   );
@@ -20,6 +20,8 @@ export default function EventList({ events, onEdit }) {
           <ListItemButton
             key={ev.id}
             onClick={() => onEdit && onEdit(ev)}
+            onMouseEnter={() => onHoverDate && onHoverDate(new Date(ev.dateTime))}
+            onMouseLeave={() => onHoverDate && onHoverDate(null)}
             sx={{
               mb: 1,
               border: 1,


### PR DESCRIPTION
## Summary
- allow `EventList` to signal event hover
- track hovered date in `App`
- highlight calendar cells on hover via `Calendar`
- test hovering behaviour

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_684b0397c03c8331a7445c5909e1beb0