### PR TITLE
Show past events with strikethrough

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -96,3 +96,16 @@ test('week view includes Saturday events', () => {
   window.localStorage.removeItem('events');
 });
 
+test('past events are shown with strikethrough', () => {
+  const past = new Date();
+  past.setDate(past.getDate() - 1);
+  const events = [
+    { id: 6, title: 'Past Event', dateTime: past.toISOString() }
+  ];
+  window.localStorage.setItem('events', JSON.stringify(events));
+  render(<App />);
+  const item = screen.getByText('Past Event');
+  expect(item).toHaveStyle('text-decoration: line-through');
+  window.localStorage.removeItem('events');
+});
+

--- a/src/EventList.js
+++ b/src/EventList.js
@@ -16,35 +16,39 @@ export default function EventList({ events, onEdit, onHoverDate }) {
             <Typography variant="body2">No events</Typography>
           </ListItemButton>
         )}
-        {sortedEvents.map((ev) => (
-          <ListItemButton
-            key={ev.id}
-            onClick={() => onEdit && onEdit(ev)}
-            onMouseEnter={() => onHoverDate && onHoverDate(new Date(ev.dateTime))}
-            onMouseLeave={() => onHoverDate && onHoverDate(null)}
-            sx={{
-              mb: 1,
-              border: 1,
-              borderColor: 'divider',
-              borderRadius: 1,
-              transition: 'background-color 0.2s, border-color 0.2s, transform 0.1s',
-              '&:hover': {
-                backgroundColor: 'action.hover',
-                borderColor: 'primary.main',
-                transform: 'translateY(-2px)'
-              }
-            }}
-          >
-            <Box sx={{ width: 12, height: 12, borderRadius: '50%', backgroundColor: ev.color || 'secondary.main', mr: 2 }} />
-            <Box sx={{ flexGrow: 1 }}>
-              <Typography variant="subtitle1">{ev.title}</Typography>
-              <Typography variant="body2">
-                {new Date(ev.dateTime).toLocaleString()}
-                {ev.duration ? ` - ${ev.duration} min` : ''}
-              </Typography>
-            </Box>
-          </ListItemButton>
-        ))}
+        {sortedEvents.map((ev) => {
+          const isPast = new Date(ev.dateTime) < new Date();
+          return (
+            <ListItemButton
+              key={ev.id}
+              onClick={() => onEdit && onEdit(ev)}
+              onMouseEnter={() => onHoverDate && onHoverDate(new Date(ev.dateTime))}
+              onMouseLeave={() => onHoverDate && onHoverDate(null)}
+              sx={{
+                mb: 1,
+                border: 1,
+                borderColor: 'divider',
+                borderRadius: 1,
+                transition: 'background-color 0.2s, border-color 0.2s, transform 0.1s',
+                '&:hover': {
+                  backgroundColor: 'action.hover',
+                  borderColor: 'primary.main',
+                  transform: 'translateY(-2px)'
+                }
+              }}
+              data-testid={`event-item-${ev.id}`}
+            >
+              <Box sx={{ width: 12, height: 12, borderRadius: '50%', backgroundColor: ev.color || 'secondary.main', mr: 2 }} />
+              <Box sx={{ flexGrow: 1 }}>
+                <Typography variant="subtitle1" sx={{ textDecoration: isPast ? 'line-through' : 'none' }}>{ev.title}</Typography>
+                <Typography variant="body2" sx={{ textDecoration: isPast ? 'line-through' : 'none' }}>
+                  {new Date(ev.dateTime).toLocaleString()}
+                  {ev.duration ? ` - ${ev.duration} min` : ''}
+                </Typography>
+              </Box>
+            </ListItemButton>
+          );
+        })}
       </List>
     </Box>
   );

--- a/src/EventManager.js
+++ b/src/EventManager.js
@@ -231,27 +231,31 @@ export default function EventManager({ open, onClose, defaultDate, events, setEv
                 <Typography variant="body2">No events</Typography>
               </ListItem>
             )}
-            {eventsForDay.map((ev) => (
-              <ListItem
-                key={ev.id}
-                secondaryAction={
-                  <IconButton edge="end" aria-label="delete" onClick={() => handleDelete(ev.id)}>
-                    <Delete />
-                  </IconButton>
-                }
-                onClick={() => handleEdit(ev.id)}
-                button
-              >
-                <Box sx={{ width: 12, height: 12, borderRadius: '50%', backgroundColor: ev.color || 'secondary.main', mr: 2 }} />
-                <Box sx={{ flexGrow: 1 }}>
-                  <Typography variant="subtitle1">{ev.title}</Typography>
-                  <Typography variant="body2">
-                    {new Date(ev.dateTime).toLocaleString()}
-                    {ev.duration ? ` - ${ev.duration} min` : ''}
-                  </Typography>
-                </Box>
-              </ListItem>
-            ))}
+            {eventsForDay.map((ev) => {
+              const isPast = new Date(ev.dateTime) < new Date();
+              return (
+                <ListItem
+                  key={ev.id}
+                  secondaryAction={
+                    <IconButton edge="end" aria-label="delete" onClick={() => handleDelete(ev.id)}>
+                      <Delete />
+                    </IconButton>
+                  }
+                  onClick={() => handleEdit(ev.id)}
+                  button
+                  data-testid={`manager-item-${ev.id}`}
+                >
+                  <Box sx={{ width: 12, height: 12, borderRadius: '50%', backgroundColor: ev.color || 'secondary.main', mr: 2 }} />
+                  <Box sx={{ flexGrow: 1 }}>
+                    <Typography variant="subtitle1" sx={{ textDecoration: isPast ? 'line-through' : 'none' }}>{ev.title}</Typography>
+                    <Typography variant="body2" sx={{ textDecoration: isPast ? 'line-through' : 'none' }}>
+                      {new Date(ev.dateTime).toLocaleString()}
+                      {ev.duration ? ` - ${ev.duration} min` : ''}
+                    </Typography>
+                  </Box>
+                </ListItem>
+              );
+            })}
           </List>
         )}
       </DialogContent>


### PR DESCRIPTION
## Summary
- mark past events with `text-decoration: line-through`
- update event manager list to display past events with a strikethrough
- add regression test verifying past events render with line-through

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_684b1cd05a8083319fc452d12962a123