### PR TITLE
Add countdown labels to events

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -109,3 +109,15 @@ test('past events are shown with strikethrough', () => {
   window.localStorage.removeItem('events');
 });
 
+test('shows days until each event', () => {
+  const future = new Date();
+  future.setDate(future.getDate() + 3);
+  const events = [
+    { id: 7, title: 'Future Event', dateTime: future.toISOString() }
+  ];
+  window.localStorage.setItem('events', JSON.stringify(events));
+  render(<App />);
+  expect(screen.getByText(/in 3 days/i)).toBeInTheDocument();
+  window.localStorage.removeItem('events');
+});
+

--- a/src/EventList.js
+++ b/src/EventList.js
@@ -1,7 +1,19 @@
 import React from 'react';
 import { Box, List, ListItemButton, Typography } from '@mui/material';
+import { differenceInCalendarDays } from 'date-fns';
 
 export default function EventList({ events, onEdit, onHoverDate }) {
+  const formatDaysUntil = (dateStr) => {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const date = new Date(dateStr);
+    date.setHours(0, 0, 0, 0);
+    const diff = differenceInCalendarDays(date, today);
+    if (diff === 0) return 'Today';
+    if (diff > 0) return `in ${diff} day${diff > 1 ? 's' : ''}`;
+    const past = Math.abs(diff);
+    return `${past} day${past > 1 ? 's' : ''} ago`;
+  };
   const sortedEvents = [...events].sort(
     (a, b) => new Date(a.dateTime) - new Date(b.dateTime)
   );
@@ -44,6 +56,7 @@ export default function EventList({ events, onEdit, onHoverDate }) {
                 <Typography variant="body2" sx={{ textDecoration: isPast ? 'line-through' : 'none' }}>
                   {new Date(ev.dateTime).toLocaleString()}
                   {ev.duration ? ` - ${ev.duration} min` : ''}
+                  {` (${formatDaysUntil(ev.dateTime)})`}
                 </Typography>
               </Box>
             </ListItemButton>


### PR DESCRIPTION
## Summary
- show how many days until or since an event in the list
- test displaying countdown for events

## Testing
- `npm test -- -u` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_684b1ffd445483319c4012bb6882150e