### PR TITLE
Add printable itinerary feature

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -3,12 +3,14 @@ import Calendar from './Calendar';
 import EventManager from './EventManager';
 import EventList from './EventList';
 import DateSidebar from './DateSidebar';
+import ItineraryDialog from './ItineraryDialog';
 import {
   Container,
   Box,
   AppBar,
   Toolbar,
-  Typography
+  Typography,
+  Button
 } from '@mui/material';
 import { useState, useEffect } from 'react';
 
@@ -19,6 +21,7 @@ function App() {
   const [hoveredDate, setHoveredDate] = useState(null);
   const [hoveredCalendarDate, setHoveredCalendarDate] = useState(null);
   const [visibleRange, setVisibleRange] = useState({ start: null, end: null });
+  const [itineraryOpen, setItineraryOpen] = useState(false);
   const [events, setEvents] = useState(() => {
     const stored = localStorage.getItem('events');
     return stored ? JSON.parse(stored) : [];
@@ -67,6 +70,7 @@ function App() {
           <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
             My Calendar
           </Typography>
+          <Button color="inherit" onClick={() => setItineraryOpen(true)}>Itinerary</Button>
         </Toolbar>
       </AppBar>
       <Container maxWidth="md" className="App">
@@ -112,6 +116,11 @@ function App() {
               d.getDate() === hoveredCalendarDate.getDate()
             );
           }) : []}
+        />
+        <ItineraryDialog
+          open={itineraryOpen}
+          onClose={() => setItineraryOpen(false)}
+          events={events}
         />
       </Container>
     </>

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -121,3 +121,20 @@ test('shows days until each event', () => {
   window.localStorage.removeItem('events');
 });
 
+
+test('itinerary dialog shows events in range', () => {
+  const today = new Date();
+  const tomorrow = new Date();
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  const events = [
+    { id: 8, title: 'Today Event', dateTime: today.toISOString() },
+    { id: 9, title: 'Tomorrow Event', dateTime: tomorrow.toISOString() }
+  ];
+  window.localStorage.setItem('events', JSON.stringify(events));
+  render(<App />);
+  const btn = screen.getByRole('button', { name: /itinerary/i });
+  fireEvent.click(btn);
+  expect(screen.getByText('Today Event')).toBeInTheDocument();
+  expect(screen.queryByText('Tomorrow Event')).toBeNull();
+  window.localStorage.removeItem('events');
+});

--- a/src/ItineraryDialog.js
+++ b/src/ItineraryDialog.js
@@ -1,0 +1,85 @@
+import React, { useState, useRef } from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Box,
+  Typography
+} from '@mui/material';
+import { LocalizationProvider, DatePicker } from '@mui/x-date-pickers';
+import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+
+export default function ItineraryDialog({ open, onClose, events = [] }) {
+  const [startDate, setStartDate] = useState(new Date());
+  const [endDate, setEndDate] = useState(new Date());
+  const printRef = useRef(null);
+
+  const filtered = events.filter(ev => {
+    const d = new Date(ev.dateTime);
+    const start = new Date(startDate); start.setHours(0,0,0,0);
+    const end = new Date(endDate); end.setHours(23,59,59,999);
+    return d >= start && d <= end;
+  }).sort((a,b) => new Date(a.dateTime) - new Date(b.dateTime));
+
+  const handlePrint = () => {
+    if (!printRef.current) return;
+    const wnd = window.open('', '_blank');
+    if (!wnd) return;
+    wnd.document.write(
+      `<html><head><title>Itinerary</title></head><body>${printRef.current.innerHTML}</body></html>`
+    );
+    wnd.document.close();
+    wnd.focus();
+    wnd.print();
+    wnd.close();
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+      <DialogTitle>Itinerary</DialogTitle>
+      <DialogContent>
+        <LocalizationProvider dateAdapter={AdapterDateFns}>
+          <Box sx={{ display: 'flex', gap: 2, mb: 2 }}>
+            <DatePicker
+              label="Start Date"
+              value={startDate}
+              onChange={(v) => v && setStartDate(v)}
+              slotProps={{ textField: { variant: 'outlined' } }}
+            />
+            <DatePicker
+              label="End Date"
+              value={endDate}
+              onChange={(v) => v && setEndDate(v)}
+              slotProps={{ textField: { variant: 'outlined' } }}
+            />
+          </Box>
+        </LocalizationProvider>
+        <Box ref={printRef}>
+          {filtered.length === 0 && (
+            <Typography variant="body2">No events</Typography>
+          )}
+          {filtered.map(ev => (
+            <Box key={ev.id} sx={{ mb: 1 }}>
+              <Typography variant="subtitle1">{ev.title}</Typography>
+              <Typography variant="body2">
+                {new Date(ev.dateTime).toLocaleString()}
+                {ev.location ? ` - ${ev.location}` : ''}
+              </Typography>
+              {ev.description && (
+                <Typography variant="body2">{ev.description}</Typography>
+              )}
+            </Box>
+          ))}
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handlePrint} disabled={filtered.length === 0}>
+          Download PDF
+        </Button>
+        <Button onClick={onClose}>Close</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Summary
- create `ItineraryDialog` with date range and print capability
- add `Itinerary` button to app bar
- open new dialog to list events in the chosen range
- cover the itinerary dialog with a new test

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ba455f8e48326902a905b84edafb8