### PR TITLE
Add location autocomplete and map preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ npm install
 
 This installs Material UI along with the `@mui/x-date-pickers` package used by the event manager.
 
+Internet access is required at runtime for the location search and map preview, which rely on the public OpenStreetMap API.
+
 ## Available Scripts
 
 In the project directory, you can run:

--- a/src/EventManager.js
+++ b/src/EventManager.js
@@ -15,6 +15,8 @@ import {
 import { Delete } from '@mui/icons-material';
 import { LocalizationProvider, DatePicker, TimePicker } from '@mui/x-date-pickers';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+import LocationInput from './LocationInput';
+import MapDisplay from './MapDisplay';
 
 const COLOR_OPTIONS = [
   { name: 'Coral Red', value: '#FF6B6B' },
@@ -47,6 +49,7 @@ export default function EventManager({ open, onClose, defaultDate, events, setEv
   const [dateTime, setDateTime] = useState(createDefaultDateTime());
   const [duration, setDuration] = useState('');
   const [location, setLocation] = useState('');
+  const [locationMeta, setLocationMeta] = useState(null);
   const [description, setDescription] = useState('');
   const [color, setColor] = useState(COLOR_OPTIONS[0].value);
   const [editingId, setEditingId] = useState(null);
@@ -56,6 +59,7 @@ export default function EventManager({ open, onClose, defaultDate, events, setEv
     setDateTime(createDefaultDateTime());
     setDuration('');
     setLocation('');
+    setLocationMeta(null);
     setDescription('');
     setColor(COLOR_OPTIONS[0].value);
     setEditingId(null);
@@ -79,6 +83,16 @@ export default function EventManager({ open, onClose, defaultDate, events, setEv
       setDateTime(new Date(editingEvent.dateTime));
       setDuration(editingEvent.duration || '');
       setLocation(editingEvent.location || '');
+      setLocationMeta(
+        editingEvent.locationLat != null && editingEvent.locationLon != null
+          ? {
+              address: editingEvent.location,
+              latitude: editingEvent.locationLat,
+              longitude: editingEvent.locationLon,
+              placeId: editingEvent.locationId,
+            }
+          : null
+      );
       setDescription(editingEvent.description || '');
       setColor(editingEvent.color || COLOR_OPTIONS[0].value);
       setEditingId(editingEvent.id);
@@ -94,6 +108,9 @@ export default function EventManager({ open, onClose, defaultDate, events, setEv
       dateTime: dateTime ? dateTime.toISOString() : new Date().toISOString(),
       duration,
       location,
+      locationLat: locationMeta?.latitude || null,
+      locationLon: locationMeta?.longitude || null,
+      locationId: locationMeta?.placeId || null,
       description,
       color
     };
@@ -113,6 +130,16 @@ export default function EventManager({ open, onClose, defaultDate, events, setEv
     setDateTime(new Date(ev.dateTime));
     setDuration(ev.duration || '');
     setLocation(ev.location || '');
+    setLocationMeta(
+      ev.locationLat != null && ev.locationLon != null
+        ? {
+            address: ev.location,
+            latitude: ev.locationLat,
+            longitude: ev.locationLon,
+            placeId: ev.locationId,
+          }
+        : null
+    );
     setDescription(ev.description || '');
     setColor(ev.color || COLOR_OPTIONS[0].value);
     setEditingId(id);
@@ -185,12 +212,14 @@ export default function EventManager({ open, onClose, defaultDate, events, setEv
             value={duration}
             onChange={(e) => setDuration(e.target.value)}
           />
-        <TextField
-          label="Location"
-          value={location}
-          onChange={(e) => setLocation(e.target.value)}
-          fullWidth
+        <LocationInput
+          value={locationMeta || { address: location }}
+          onChange={(meta) => {
+            setLocation(meta.address);
+            setLocationMeta(meta);
+          }}
         />
+        <MapDisplay latitude={locationMeta?.latitude} longitude={locationMeta?.longitude} />
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
           <Typography variant="body2" sx={{ minWidth: 50 }}>
             Color

--- a/src/LocationInput.js
+++ b/src/LocationInput.js
@@ -1,0 +1,78 @@
+import React, { useState, useEffect } from 'react';
+import { TextField, Autocomplete, CircularProgress } from '@mui/material';
+
+export default function LocationInput({ value, onChange }) {
+  const [input, setInput] = useState(value?.address || '');
+  const [options, setOptions] = useState([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!input || input.length < 3) {
+      setOptions([]);
+      return;
+    }
+    let active = true;
+    setLoading(true);
+    const controller = new AbortController();
+    fetch(
+      `https://nominatim.openstreetmap.org/search?format=json&addressdetails=1&q=${encodeURIComponent(
+        input
+      )}`,
+      { signal: controller.signal, headers: { 'Accept-Language': 'en' } }
+    )
+      .then((res) => res.json())
+      .then((data) => {
+        if (active) {
+          setOptions(data);
+        }
+      })
+      .catch(() => {})
+      .finally(() => active && setLoading(false));
+    return () => {
+      active = false;
+      controller.abort();
+    };
+  }, [input]);
+
+  const handleSelect = (_, newValue) => {
+    if (newValue) {
+      setInput(newValue.display_name);
+      onChange &&
+        onChange({
+          address: newValue.display_name,
+          latitude: parseFloat(newValue.lat),
+          longitude: parseFloat(newValue.lon),
+          placeId: newValue.osm_id,
+        });
+    }
+  };
+
+  return (
+    <Autocomplete
+      freeSolo
+      options={options}
+      getOptionLabel={(option) => option.display_name || option}
+      filterOptions={(x) => x}
+      onInputChange={(_, newInput) => setInput(newInput)}
+      inputValue={input}
+      onChange={handleSelect}
+      loading={loading}
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          label="Location"
+          fullWidth
+          InputProps={{
+            ...params.InputProps,
+            endAdornment: (
+              <>
+                {loading ? <CircularProgress color="inherit" size={20} /> : null}
+                {params.InputProps.endAdornment}
+              </>
+            ),
+          }}
+        />
+      )}
+    />
+  );
+}

--- a/src/MapDisplay.js
+++ b/src/MapDisplay.js
@@ -1,0 +1,17 @@
+import React from 'react';
+
+export default function MapDisplay({ latitude, longitude }) {
+  if (latitude == null || longitude == null) return null;
+  const bbox = `${longitude - 0.01},${latitude - 0.01},${longitude + 0.01},${latitude + 0.01}`;
+  const src = `https://www.openstreetmap.org/export/embed.html?bbox=${bbox}&layer=mapnik&marker=${latitude},${longitude}`;
+  return (
+    <iframe
+      title="map"
+      width="100%"
+      height="200"
+      style={{ border: 0 }}
+      loading="lazy"
+      src={src}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- add `LocationInput` component that queries OpenStreetMap for suggestions
- display selected location on an embedded map via `MapDisplay`
- integrate the new components into `EventManager`
- note map API requirement in README

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_684b58d65ef883319401583c5299f455