### PR TITLE
Add plus button to create events

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -94,6 +94,11 @@ function App() {
                 : events}
               onEdit={handleEditEvent}
               onHoverDate={setHoveredDate}
+              onAdd={() => {
+                setSelectedDate(null);
+                setEditingEvent(null);
+                setDialogOpen(true);
+              }}
             />
           </Box>
         </Box>

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -138,3 +138,10 @@ test('itinerary dialog shows events in range', () => {
   expect(screen.queryByText('Tomorrow Event')).toBeNull();
   window.localStorage.removeItem('events');
 });
+
+test('add event button opens manager', () => {
+  render(<App />);
+  const addBtn = screen.getByTestId('add-event-button');
+  fireEvent.click(addBtn);
+  expect(screen.getByText(/manage events/i)).toBeInTheDocument();
+});

--- a/src/EventList.js
+++ b/src/EventList.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Box, List, ListItemButton, Typography, IconButton } from '@mui/material';
-import { Add } from '@mui/icons-material';
+import AddIcon from '@mui/icons-material/Add';
 import { differenceInCalendarDays } from 'date-fns';
 
 export default function EventList({ events, onEdit, onHoverDate, onAdd }) {
@@ -25,8 +25,14 @@ export default function EventList({ events, onEdit, onHoverDate, onAdd }) {
           Events
         </Typography>
         {onAdd && (
-          <IconButton aria-label="add event" onClick={onAdd} size="small" data-testid="add-event-button">
-            <Add />
+          <IconButton
+            aria-label="add event"
+            onClick={onAdd}
+            size="small"
+            color="primary"
+            data-testid="add-event-button"
+          >
+            <AddIcon />
           </IconButton>
         )}
       </Box>

--- a/src/EventList.js
+++ b/src/EventList.js
@@ -1,8 +1,9 @@
 import React from 'react';
-import { Box, List, ListItemButton, Typography } from '@mui/material';
+import { Box, List, ListItemButton, Typography, IconButton } from '@mui/material';
+import { Add } from '@mui/icons-material';
 import { differenceInCalendarDays } from 'date-fns';
 
-export default function EventList({ events, onEdit, onHoverDate }) {
+export default function EventList({ events, onEdit, onHoverDate, onAdd }) {
   const formatDaysUntil = (dateStr) => {
     const today = new Date();
     today.setHours(0, 0, 0, 0);
@@ -19,9 +20,16 @@ export default function EventList({ events, onEdit, onHoverDate }) {
   );
   return (
     <Box sx={{ width: '100%', p: 2 }}>
-      <Typography variant="h6" align="center" gutterBottom>
-        Events
-      </Typography>
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 1 }}>
+        <Typography variant="h6" align="center" sx={{ flexGrow: 1 }} gutterBottom>
+          Events
+        </Typography>
+        {onAdd && (
+          <IconButton aria-label="add event" onClick={onAdd} size="small" data-testid="add-event-button">
+            <Add />
+          </IconButton>
+        )}
+      </Box>
       <List sx={{ maxHeight: '70vh', overflow: 'auto', p: 0, pt: 1 }}>
         {sortedEvents.length === 0 && (
           <ListItemButton disabled sx={{ border: 1, borderColor: 'divider', mb: 1, borderRadius: 1 }}>


### PR DESCRIPTION
## Summary
- add an `onAdd` prop to `EventList` and render a new `+` button
- wire up the button in `App.js` to open `EventManager`
- test that clicking the add button opens the event manager

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_68509a6942e08331bde51151d0f57bf3