### PR TITLE
Fix event manager add dialog

### DIFF
--- a/src/EventManager.js
+++ b/src/EventManager.js
@@ -159,9 +159,9 @@ export default function EventManager({ open, onClose, defaultDate, events, setEv
     ? events.filter(ev =>
         isSameDay(new Date(ev.dateTime), new Date(defaultDate))
       )
-    : events;
+    : [];
 
-  const showList = defaultDate || !editingEvent;
+  const showList = Boolean(defaultDate);
 
   return (
     <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">


### PR DESCRIPTION
## Summary
- only show the event list in the manager when a date is selected

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_68509f4fcca08331b63c7163de1f21de